### PR TITLE
feat: ✨ add support for weekly goals with ISO week numbering

### DIFF
--- a/tests/routes/test_goals.py
+++ b/tests/routes/test_goals.py
@@ -92,6 +92,40 @@ def test_add_multiple_goals_month(
     assert len(added_goals.data) == 12
 
 
+@pytest.mark.parametrize(
+    ("month", "week", "exp_number_of_goals"),
+    [(None, 1, 1), (1, None, 5), (None, None, 52)],
+)
+def test_add_goals_week(
+    client: TestClient,
+    temp_user_token: str,
+    month: int | None,
+    week: int | None,
+    exp_number_of_goals: int,
+) -> None:
+    goal_data = {
+        "name": "New Goal",
+        "description": "A newly created goal",
+        "target": 2,
+        "temporal_type": TemportalType.WEEKLY,
+        "year": 2025,
+        "month": month,
+        "week": week,
+        "type": GoalType.ACTIVITY,
+        "aggregation": GoalAggregation.COUNT,
+    }
+
+    response = client.put(
+        "/goal",
+        headers={"Authorization": f"Bearer {temp_user_token}"},
+        json=goal_data,
+    )
+
+    assert response.status_code == 200
+    added_goals = ListResponse[GoalPublic].model_validate(response.json())
+    assert len(added_goals.data) == exp_number_of_goals
+
+
 def test_add_goal_invalid_configuration(
     client: TestClient,
     temp_user_token: str,

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -314,3 +314,321 @@ def test_validate_contraints(
         assert isinstance(res, GoalContraints)
     else:
         assert isinstance(res, tuple)
+
+
+@pytest.mark.parametrize(
+    ("temporal_type", "year", "month", "week", "is_valid"),
+    [
+        # Valid weekly goals
+        (TemportalType.WEEKLY, 2025, None, 3, True),
+        (TemportalType.WEEKLY, 2025, None, 1, True),
+        (TemportalType.WEEKLY, 2025, None, 52, True),
+        (TemportalType.WEEKLY, 2025, None, 53, True),
+        # Invalid: weekly with month set
+        (TemportalType.WEEKLY, 2025, 5, 3, False),
+        # Invalid: weekly without week
+        (TemportalType.WEEKLY, 2025, None, None, False),
+        # Invalid: weekly with invalid week (0)
+        (TemportalType.WEEKLY, 2025, None, 0, False),
+        # Invalid: weekly with invalid week (54)
+        (TemportalType.WEEKLY, 2025, None, 54, False),
+        # Invalid: weekly with invalid week (-1)
+        (TemportalType.WEEKLY, 2025, None, -1, False),
+        # YEARLY with week set
+        (TemportalType.YEARLY, 2025, None, 3, False),
+        # MONTHLY with week set
+        (TemportalType.MONTHLY, 2025, 5, 3, False),
+    ],
+)
+def test_temporal_validation_weekly(
+    temporal_type: TemportalType,
+    year: int,
+    month: int | None,
+    week: int | None,
+    is_valid: bool,
+) -> None:
+    res = _validate_temporal_setup(
+        GoalCreate(
+            name="Some Name",
+            target=10,
+            type=GoalType.ACTIVITY,
+            aggregation=GoalAggregation.COUNT,
+            year=year,
+            month=month,
+            week=week,
+            temporal_type=temporal_type,
+        )
+    )
+
+    if is_valid:
+        assert res is None
+    else:
+        assert isinstance(res, tuple)
+
+
+@pytest.mark.parametrize(
+    (
+        "goal_week",
+        "current_updated",
+        "agg",
+        "exp_current_value",
+    ),
+    [
+        # Week 3 (Jan 13-19, 2025): activities on 1/14 and 1/15
+        (3, None, GoalAggregation.TOTAL_DISTANCE, 40),
+        (3, None, GoalAggregation.COUNT, 2),
+        (3, None, GoalAggregation.DURATION, 60 * 60),  # 60 minutes total
+        (3, None, GoalAggregation.AVG_DISTANCE, 20),  # (10+30)/2
+        (3, None, GoalAggregation.MAX_DISTANCE, 30),
+        # Week 1 (Dec 30, 2024 - Jan 5, 2025): activities on 1/2 and 1/3
+        (1, None, GoalAggregation.TOTAL_DISTANCE, 50),
+        (1, None, GoalAggregation.COUNT, 2),
+        # Incremental update: only count activities created after current_updated
+        (3, datetime(2025, 1, 14, 20), GoalAggregation.TOTAL_DISTANCE, 30),
+        # Week 52 (no activities): should return 0
+        (52, None, GoalAggregation.COUNT, 0),
+    ],
+)
+def test_update_weekly_activity_goal(
+    db: Session,
+    temp_user_id: UUID,
+    goal_week: int,
+    current_updated: datetime | None,
+    agg: GoalAggregation,
+    exp_current_value: float,
+) -> None:
+    """Test weekly goal state updates with various aggregations."""
+    # Week 3 activities: Jan 13-19, 2025 (Mon-Sun)
+    activity_week3_1 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 14, 12),  # Tuesday, week 3
+        distance=10,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity Week 3 - 1",
+        created_at=datetime(2025, 1, 14, 18),
+    )
+    activity_week3_2 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 15, 12),  # Wednesday, week 3
+        distance=30,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity Week 3 - 2",
+        created_at=datetime(2025, 1, 15, 18),
+    )
+
+    # Week 1 activities: Dec 30, 2024 - Jan 5, 2025 (includes Dec 30-31, 2024)
+    activity_week1_1 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 2, 12),  # Thursday, week 1
+        distance=20,
+        duration=timedelta(minutes=20),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity Week 1 - 1",
+        created_at=datetime(2025, 1, 2, 18),
+    )
+    activity_week1_2 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 3, 12),  # Friday, week 1
+        distance=30,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity Week 1 - 2",
+        created_at=datetime(2025, 1, 3, 18),
+    )
+
+    # Activity in week 4 (should not be counted for weeks 1 or 3)
+    activity_week4 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 21, 12),  # Tuesday, week 4
+        distance=25,
+        duration=timedelta(minutes=25),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity Week 4",
+        created_at=datetime(2025, 1, 21, 18),
+    )
+
+    goal = Goal(
+        user_id=temp_user_id,
+        name="Weekly Goal",
+        target=100,
+        temporal_type=TemportalType.WEEKLY,
+        year=2025,
+        month=None,
+        week=goal_week,
+        type=GoalType.ACTIVITY,
+        aggregation=agg,
+        current=0,
+        current_updated=current_updated,
+        constraints={},
+    )
+
+    db.add_all(
+        [
+            activity_week3_1,
+            activity_week3_2,
+            activity_week1_1,
+            activity_week1_2,
+            activity_week4,
+            goal,
+        ]
+    )
+    db.commit()
+    db.refresh(goal)
+
+    update_goal_state(session=db, user_id=temp_user_id, goal=goal)
+
+    updated_goal = db.get(Goal, goal.id)
+    assert updated_goal is not None
+    assert updated_goal.current == exp_current_value
+
+
+def test_weekly_goal_year_boundary(
+    db: Session,
+    temp_user_id: UUID,
+) -> None:
+    """
+    Test that week 1 of 2025 correctly includes activities from
+    Dec 30-31, 2024 (which belong to ISO week 1 of 2025).
+    """
+    # Activity on Dec 30, 2024 (ISO week 1 of 2025)
+    activity_dec30 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2024, 12, 30, 12),
+        distance=10,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity on Dec 30",
+        created_at=datetime(2024, 12, 30, 18),
+    )
+
+    # Activity on Dec 31, 2024 (ISO week 1 of 2025)
+    activity_dec31 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2024, 12, 31, 12),
+        distance=15,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity on Dec 31",
+        created_at=datetime(2024, 12, 31, 18),
+    )
+
+    # Activity on Jan 1, 2025 (ISO week 1 of 2025)
+    activity_jan1 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 1, 12),
+        distance=20,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity on Jan 1",
+        created_at=datetime(2025, 1, 1, 18),
+    )
+
+    # Goal for week 1 of 2025
+    goal = Goal(
+        user_id=temp_user_id,
+        name="Week 1 Goal",
+        target=100,
+        temporal_type=TemportalType.WEEKLY,
+        year=2025,
+        month=None,
+        week=1,
+        type=GoalType.ACTIVITY,
+        aggregation=GoalAggregation.TOTAL_DISTANCE,
+        current=0,
+        constraints={},
+    )
+
+    db.add_all([activity_dec30, activity_dec31, activity_jan1, goal])
+    db.commit()
+    db.refresh(goal)
+
+    update_goal_state(session=db, user_id=temp_user_id, goal=goal)
+
+    updated_goal = db.get(Goal, goal.id)
+    assert updated_goal is not None
+    # Should include all three activities: 10 + 15 + 20 = 45
+    assert updated_goal.current == 45
+
+
+def test_weekly_goal_incremental_update(
+    db: Session,
+    temp_user_id: UUID,
+) -> None:
+    """
+    Test that incremental updates work correctly for weekly goals
+    (only new activities are counted, not activities from before current_updated).
+    """
+    # First activity created at 2025-01-14 18:00
+    activity_1 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 14, 12),
+        distance=20,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity 1",
+        created_at=datetime(2025, 1, 14, 18),
+    )
+
+    # Second activity created at 2025-01-16 18:00 (after current_updated)
+    activity_2 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 15, 12),
+        distance=30,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity 2",
+        created_at=datetime(2025, 1, 16, 18),
+    )
+
+    # Third activity created at 2025-01-20 18:00 (after current_updated)
+    activity_3 = Activity(
+        user_id=temp_user_id,
+        start=datetime(2025, 1, 17, 12),
+        distance=25,
+        duration=timedelta(minutes=30),
+        type_id=1,
+        sub_type_id=None,
+        name="Activity 3",
+        created_at=datetime(2025, 1, 20, 18),
+    )
+
+    # Goal with current_updated = 2025-01-15 19:00
+    # This means only activities created AFTER 2025-01-15 19:00 should be counted
+    goal = Goal(
+        user_id=temp_user_id,
+        name="Weekly Goal",
+        target=100,
+        temporal_type=TemportalType.WEEKLY,
+        year=2025,
+        month=None,
+        week=3,
+        type=GoalType.ACTIVITY,
+        aggregation=GoalAggregation.TOTAL_DISTANCE,
+        current=0,
+        current_updated=datetime(2025, 1, 15, 19),
+        constraints={},
+    )
+
+    db.add_all([activity_1, activity_2, activity_3, goal])
+    db.commit()
+    db.refresh(goal)
+
+    update_goal_state(session=db, user_id=temp_user_id, goal=goal)
+
+    updated_goal = db.get(Goal, goal.id)
+    assert updated_goal is not None
+    # Only activity_2 and activity_3 should be counted: 30 + 25 = 55
+    # activity_1 was created at 18:00 which is before current_updated (19:00)
+    assert updated_goal.current == 55

--- a/verve_backend/core/date_utils.py
+++ b/verve_backend/core/date_utils.py
@@ -40,6 +40,58 @@ def get_month_grid(year: int, month: int) -> list[list[date]]:
     return grid
 
 
+def get_all_dates_in_month(year: int, month: int) -> list[date]:
+    """
+    Generate all dates for a given month.
+
+    Args:
+        year: The year
+        month: The month (1-12)
+
+    Returns:
+        List of all dates in the month
+    """
+    first_day = date(year, month, 1)
+
+    if month == 12:
+        last_day = date(year + 1, 1, 1) - timedelta(days=1)
+    else:
+        last_day = date(year, month + 1, 1) - timedelta(days=1)
+
+    dates = []
+    current_date = first_day
+    while current_date <= last_day:
+        dates.append(current_date)
+        current_date += timedelta(days=1)
+
+    return dates
+
+
+def get_week_numbers_between_dates(start_date: date, end_date: date) -> list[int]:
+    """
+    Generate all ISO week numbers between two dates (inclusive).
+
+    Args:
+        start_date: Start date
+        end_date: End date
+
+    Returns:
+        List of week numbers for all weeks between the dates
+    """
+    weeks = []
+    current_date = start_date
+
+    while current_date <= end_date:
+        week_number = current_date.isocalendar()[1]
+
+        if not weeks or weeks[-1] != week_number:
+            weeks.append(week_number)
+
+        current_date += timedelta(days=1)
+
+    return weeks
+
+
 if __name__ == "__main__":
     from pprint import pprint
 

--- a/verve_backend/models.py
+++ b/verve_backend/models.py
@@ -401,6 +401,7 @@ class GoalBase(SQLModel):
     temporal_type: TemportalType = Field(default=TemportalType.YEARLY)
     year: int = Field(default=datetime.now().year)
     month: int | None = Field(default=None)
+    week: int | None = Field(default=None)
 
     type: GoalType = Field()
     aggregation: GoalAggregation = Field()


### PR DESCRIPTION
- Add `week` field to GoalBase model for ISO week specification • Implement weekly goal creation with automatic week expansion when week is None 
- Add temporal validation for weekly goals (week range 1-53, no month/week conflicts) 
- Introduce date utility functions: get_all_dates_in_month() and get_week_numbers_between_dates() 
- Update goal state calculation to filter activities by ISO week date ranges 
- Add comprehensive test coverage for weekly goal creation, validation, and state updates 
- Support year boundary handling for week 1 (Dec 30-31 dates)